### PR TITLE
feat: Add support for `react-icons`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,14 +6,15 @@
   "packages": {
     "": {
       "name": "linkfree-cli",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "GPL-3.0",
       "dependencies": {
         "axios": "^0.27.2",
         "chalk": "^4.1.2",
         "enquirer": "^2.3.6",
         "json-format": "^1.0.1",
-        "open": "^8.4.2"
+        "open": "^8.4.2",
+        "react-icons": "^4.7.1"
       },
       "bin": {
         "linkfree-cli": "src/index.js"
@@ -185,9 +186,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
     "node_modules/json-format": {
       "version": "1.0.1",
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -236,6 +255,26 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
+      "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/supports-color": {
@@ -344,8 +383,23 @@
         "is-docker": "^2.0.0"
       }
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
     "json-format": {
       "version": "1.0.1"
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "mime-db": {
       "version": "1.52.0",
@@ -373,6 +427,21 @@
     "prettier": {
       "version": "2.7.1",
       "dev": true
+    },
+    "react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "react-icons": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
+      "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
+      "requires": {}
     },
     "supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "chalk": "^4.1.2",
     "enquirer": "^2.3.6",
     "json-format": "^1.0.1",
-    "open": "^8.4.2"
+    "open": "^8.4.2",
+    "react-icons": "^4.7.1"
   },
   "devDependencies": {
     "prettier": "^2.7.1"

--- a/src/shared/assets/icons.js
+++ b/src/shared/assets/icons.js
@@ -1,17 +1,17 @@
-const axios = require("axios");
+const FaIcons = require("react-icons/fa");
+const SaIcons = require("react-icons/si");
 let icons = [];
+
 async function geticons() {
-  try {
-    const response = await axios.get(
-      `https://raw.githubusercontent.com/EddieHubCommunity/LinkFree/main/config/icons.json`
-    );
-    icons = Object.keys(response.data);
-    return icons;
-  } catch (error) {
-    console.error(error);
-  }
+  Object.keys(FaIcons).forEach((key) => {
+    icons.push(key);
+  });
+
+  Object.keys(SaIcons).forEach((key) => {
+    icons.push(key);
+  });
+
+  return icons;
 }
 
-module.exports = {
-  geticons,
-};
+module.exports = { geticons };


### PR DESCRIPTION
- Added support for [eact-icons](https://www.npmjs.com/package/react-icons) icons. Now we will get the supported icons by LinkFreee directly from `react-icons`and will not get fetched from `githubusercontent` which is blocked in India by JIO ISP.