### PR TITLE
feat: Trigger releases and README improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**LinkFree CLI** is a command line tool that helps us to create and update your **[LinkFree](https://github.com/EddieHubCommunity/LinkFree)** profile through CLI. We can also give testimonials and events through it.
+**LinkFree CLI** is a command line tool that helps us to create and update your **[LinkFree](https://github.com/EddieHubCommunity/LinkFree)** profile through CLI. We can also give testimonials and add events through it.
 
 <br>
   


### PR DESCRIPTION
- Release didn't get triggered. PR to re-trigger it again. This is why `2.1.0` didn't get released. It was due to a permission issue.